### PR TITLE
Inject serviceManager to remove the ServiceManagerAwareInterface

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -18,12 +18,12 @@ return array(
     ),
     'service_manager' => array(
         'invokables' => array(
-            'geoip' => 'ZfSnapGeoip\Service\Geoip',
             'geoip_record' => 'ZfSnapGeoip\Entity\Record',
             'geoip_hydrator' => 'Zend\Stdlib\Hydrator\ClassMethods',
             'ZfSnapGeoip\HttpClient\Adapter' => 'Zend\Http\Client\Adapter\Curl',
         ),
         'factories' => array(
+            'geoip' => 'ZfSnapGeoip\Service\GeoipFactory',
             'ZfSnapGeoip\DatabaseConfig' => 'ZfSnapGeoip\DatabaseConfigFactory',
             'ZfSnapGeoip\HttpClient' => 'ZfSnapGeoip\HttpClientFactory',
         ),

--- a/src/ZfSnapGeoip/Service/Geoip.php
+++ b/src/ZfSnapGeoip/Service/Geoip.php
@@ -11,7 +11,6 @@ use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\EventManager;
 use Zend\Http\PhpEnvironment\Request as HttpRequest;
 use Zend\ServiceManager\ServiceManager;
-use Zend\ServiceManager\ServiceManagerAwareInterface;
 use geoiprecord as GeoipCoreRecord;
 
 /**
@@ -19,7 +18,7 @@ use geoiprecord as GeoipCoreRecord;
  *
  * @author Witold Wasiczko <witold@wasiczko.pl>
  */
-class Geoip implements ServiceManagerAwareInterface, EventManagerAwareInterface
+class Geoip implements EventManagerAwareInterface
 {
     /**
      * @var \GeoIP
@@ -55,6 +54,15 @@ class Geoip implements ServiceManagerAwareInterface, EventManagerAwareInterface
      * @var array
      */
     private $regions;
+
+    /**
+     * Geoip constructor.
+     * @param ServiceManager $serviceManager
+     */
+    public function __construct(ServiceManager $serviceManager)
+    {
+        $this->serviceManager = $serviceManager;
+    }
 
     /**
      * Destructor
@@ -242,14 +250,6 @@ class Geoip implements ServiceManagerAwareInterface, EventManagerAwareInterface
             }
         }
         return null;
-    }
-
-    /**
-     * @param ServiceManager $serviceManager
-     */
-    public function setServiceManager(ServiceManager $serviceManager)
-    {
-        $this->serviceManager = $serviceManager;
     }
 
     /**

--- a/src/ZfSnapGeoip/Service/GeoipFactory.php
+++ b/src/ZfSnapGeoip/Service/GeoipFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ZfSnapGeoip\Service;
+
+use Zend\ServiceManager\ServiceManager;
+
+class GeoipFactory
+{
+    public function __invoke(ServiceManager $serviceManager)
+    {
+        return new Geoip($serviceManager);
+    }
+}


### PR DESCRIPTION
In ZF3, the ServiceManagerAwareInterface and the associated initializer are removed. Creating a factory for the Geoip Service allows to inject the service manager as serviceLocator, which may not be a best practice but make the package compatible.